### PR TITLE
Add profiling script and update plan

### DIFF
--- a/cogit/assessment.md
+++ b/cogit/assessment.md
@@ -1,0 +1,82 @@
+# Executive Summary
+The repository provides a modular implementation of a retrieval-augmented generation (RAG) pipeline in Python. It contains components for document processing, embedding, indexing, retrieval, prompt management and LLM-based response generation. The codebase emphasizes asynchronous operations, structured logging and configurable behaviors through Pydantic models. Overall it presents a solid foundation for building AI assistants, but it lacks tests and some functionality remains unfinished or commented out.
+
+# Repository Overview and Purpose
+The project is introduced in `README.md`, describing a pipeline for efficient document retrieval and reranking with features such as vector indexing, caching and asynchronous processing【F:README.md†L1-L11】. The repository is organized as a Python package under `src/pipeline` with utilities and prompt templates.
+
+# Architecture and Structure Analysis
+The repository structure is as follows:
+```
+./
+    .gitignore
+    README.md
+    dev-requirements.txt
+    pyproject.toml
+    pytest.ini
+    requirements.txt
+    run_activate.bat
+    run_tests.bat
+    cogit/
+        assessment.md
+    src/
+        pipeline/
+            __init__.py
+            embedder.py
+            generator.py
+            indexer.py
+            processor.py
+            retriever.py
+            utils/
+                configs.py
+                logging.py
+                model.py
+                types.py
+            prompts/
+                eval_ground_truth.md
+                eval_query_generation.md
+                manager.py
+                standard.md
+```
+
+Key modules:
+- **generator.py** – orchestrates conversations and retrieval, maintaining conversation history【F:src/pipeline/generator.py†L13-L40】.
+- **indexer.py** – manages vector database interactions, uploading vectors and running maintenance tasks【F:src/pipeline/indexer.py†L28-L52】.
+- **processor.py** – handles document loading, chunking and deduplication with detailed metrics【F:src/pipeline/processor.py†L41-L89】.
+- **retriever.py** – performs dense+sparse search, reranking and caching【F:src/pipeline/retriever.py†L236-L320】.
+- **utils/** – configuration models, structured logging and LLM helpers (e.g., `LLMConfig`)【F:src/pipeline/utils/configs.py†L394-L430】.
+- **prompts/** – Markdown templates with YAML front matter for prompt management.
+
+# Functionality Assessment
+The pipeline implements a typical RAG workflow:
+1. **Document Processing** – `Processor` loads documents using `unstructured`, splits them into chunks, deduplicates and collects metrics.
+2. **Embedding** – `Embedder` provides dense embeddings (SentenceTransformers or OpenAI) and sparse embeddings (BM25).
+3. **Indexing** – `Indexer` prepares vectors and stores them in Qdrant. It supports batch uploads with retry logic and periodic maintenance.
+4. **Retrieval** – `Retriever` embeds queries, executes hybrid search, reranks results and leverages an in-memory LRU cache.
+5. **Generation** – `Generator` pulls retrieved context, composes prompts via `PromptManager` and calls an LLM client (`LLMClient`) which can fall back between Together API and Anthropic.
+
+The code is asynchronous and uses Pydantic models for structured data. Configuration classes allow customizing components for different environments.
+
+# Code Quality Evaluation
+**Strengths**
+- Good use of Pydantic models for validation and configuration.
+- Asynchronous design for potentially improved throughput.
+- Structured logging via `structlog` for detailed diagnostics.
+- Modular components (Processor, Indexer, Retriever, etc.) encourage separation of concerns.
+
+**Weaknesses**
+- No unit tests or integration tests (despite pytest configuration), making it difficult to verify behavior.
+- Several TODO comments indicate unfinished features (e.g., streaming in `Generator`, query decomposition, etc.).
+- Logging configuration may globally configure structlog each time `setup_logger` is called, which can lead to duplicate configuration.
+- Some functions handle exceptions broadly and re-raise generic `RuntimeError`, reducing error specificity.
+- Lack of explicit resource cleanup in some asynchronous functions (e.g., open file descriptors when loading with `UnstructuredFileLoader`).
+
+# Improvement Recommendations
+1. **Add Test Coverage** – Implement unit and integration tests for each component to ensure reliability and to validate asynchronous behavior. Utilize `pytest` markers already configured in `pytest.ini`.
+2. **Refine Error Handling** – Replace broad `except Exception` patterns with targeted exceptions and provide clearer propagation of errors.
+3. **Complete TODOs** – Implement streaming response support in `Generator` and finalize query decomposition logic in `Retriever` and `QueryDecomposition`.
+4. **Optimize Logging Setup** – Ensure `setup_logger` is called only once per module or use a centralized logging configuration to avoid repeated reconfiguration.
+5. **Documentation Enhancements** – Expand `README` with usage examples and instructions for setting up dependencies, along with typical pipeline workflows.
+6. **Add Automated Formatting/Linting** – Introduce tools like `black` or `ruff` to maintain consistent style.
+
+# Conclusion
+This repository lays out a flexible RAG pipeline with modular, asynchronous components and extensive configuration. While the architecture is promising, the project would benefit from test coverage, better error handling and more comprehensive documentation. Addressing these areas will improve maintainability and ensure the pipeline can scale to production workloads.

--- a/planning/001-plan-performance-analysis.md
+++ b/planning/001-plan-performance-analysis.md
@@ -1,0 +1,68 @@
+# Plan 001: Performance Analysis
+
+## Objective
+Identify bottlenecks causing ~5 minute indexing time for ~300 files and outline optimization areas.
+
+## Current Status
+Loading and indexing rely on mostly synchronous operations despite an async API. Embedding and upload steps process one document at a time.
+
+## Proposed Approach
+1. Profile each pipeline stage (loading, chunking, embedding, upload).
+2. Focus on file loading speed and embedding batching.
+3. Document findings and recommended improvements.
+
+## Dependencies
+None
+
+## Verification
+- Measure overall indexing time before and after optimizations.
+- Track per-stage timing via logging or profiling tools.
+
+## Acceptance Criteria
+- Report describing major bottlenecks and concrete optimization opportunities.
+
+## Estimated Effort
+1 day for profiling and analysis.
+
+---
+
+## Background Analysis
+The indexing process currently takes around **five minutes** for only 300 files. Although the pipeline exposes asynchronous methods, many steps execute sequentially using `asyncio.to_thread`. Key observations:
+
+### 1. Document Loading
+- Uses `DirectoryLoader` and `UnstructuredFileLoader`, loading each file sequentially.
+- `unstructured` parsing adds latency for formats like PDF or Word.
+- A `RateLimiter` can pause when many files load quickly.
+
+*Potential improvements*: adopt true async file loaders (e.g., `aiofiles`), parallelize parsing, adjust the rate limit.
+
+### 2. Chunking and Deduplication
+- Chunks accumulate sequentially before embedding starts.
+- Hash-based deduplication adds CPU overhead.
+
+*Potential improvements*: overlap chunking with loading and profile hashing cost.
+
+### 3. Embedding Generation
+- Chunks embed one document at a time.
+- Default embedder runs on CPU; OpenAI calls use small batches.
+
+*Potential improvements*: batch across documents, enable GPU, increase remote batch size and use async HTTP.
+
+### 4. Database Uploads
+- Embeddings upload per document, leading to many small batches.
+
+*Potential improvements*: combine uploads from multiple documents and tune `parallel_uploads`.
+
+### 5. Synchronous Steps in an Async Pipeline
+- Blocking operations inside `to_thread` limit concurrency so the pipeline behaves largely synchronously.
+
+*Potential improvements*: run blocking work in parallel tasks and consider a producer–consumer design.
+
+## Conclusion
+Greater concurrency in loading and embedding and larger upload batches should significantly reduce indexing time.
+
+### Initial Profiling Attempt
+An initial run of `scripts/perf_profile.py` failed because required
+dependencies such as `langchain_community` and `unstructured` are not
+installed in the current environment. Profiling cannot proceed until these
+packages are available.

--- a/planning/001-plan-performance-analysis.md
+++ b/planning/001-plan-performance-analysis.md
@@ -66,3 +66,8 @@ An initial run of `scripts/perf_profile.py` failed because required
 dependencies such as `langchain_community` and `unstructured` are not
 installed in the current environment. Profiling cannot proceed until these
 packages are available.
+
+Attempts to install the missing packages via `pip install -r requirements.txt`
+failed because the environment does not allow outbound network access. Profiling
+will remain blocked until the necessary dependencies are installed manually or a
+prebuilt environment is provided.

--- a/planning/002-plan-async-loading.md
+++ b/planning/002-plan-async-loading.md
@@ -1,0 +1,26 @@
+# Plan 002: Async File Loading
+
+## Objective
+Implement asynchronous file loading to reduce I/O wait times during indexing.
+
+## Current Status
+`DirectoryLoader` loads files sequentially and uses `asyncio.to_thread` for blocking I/O, limiting concurrency.
+
+## Proposed Approach
+1. Replace `DirectoryLoader` with an implementation using `aiofiles` or similar async library.
+2. Spawn tasks for parsing files concurrently using `asyncio.TaskGroup`.
+3. Maintain existing rate limiting but adjust thresholds for disk throughput.
+
+## Dependencies
+- Plan 001: Performance Analysis
+
+## Verification
+- Measure time taken to load a fixed number of files before and after the change.
+- Ensure loaded documents match original content.
+
+## Acceptance Criteria
+- File loading step executes concurrently and shows measurable speedup.
+- No regressions in document content or order.
+
+## Estimated Effort
+2–3 days for implementation and testing.

--- a/planning/003-plan-embedding-batching.md
+++ b/planning/003-plan-embedding-batching.md
@@ -1,0 +1,27 @@
+# Plan 003: Embedding Batching
+
+## Objective
+Improve embedding throughput by batching chunks across documents and enabling parallel execution.
+
+## Current Status
+Embeddings are generated one document at a time. For remote models, batch size is small and HTTP requests are sequential.
+
+## Proposed Approach
+1. Aggregate chunks from multiple documents into larger batches.
+2. Use asynchronous HTTP client for remote embeddings to overlap network latency.
+3. Allow configuring batch size via settings.
+4. If using SentenceTransformers locally, enable GPU execution when available.
+
+## Dependencies
+- Plan 001: Performance Analysis
+
+## Verification
+- Compare total embedding time for a fixed dataset before and after batching changes.
+- Ensure embeddings remain deterministic for the same input.
+
+## Acceptance Criteria
+- Embedding stage processes batches rather than individual documents.
+- Pipeline demonstrates reduced embedding time with correct outputs.
+
+## Estimated Effort
+2–4 days including implementation and profiling.

--- a/planning/004-plan-db-upload-optimization.md
+++ b/planning/004-plan-db-upload-optimization.md
@@ -1,0 +1,27 @@
+# Plan 004: Database Upload Optimization
+
+## Objective
+Reduce indexing time by combining uploads from multiple documents and tuning upload concurrency.
+
+## Current Status
+`Indexer.index_documents` uploads each document's vectors separately. Small batches result in frequent database calls.
+
+## Proposed Approach
+1. Buffer vectors from several documents before uploading to the database.
+2. Expose configuration for batch size and parallel uploads.
+3. Profile memory usage to prevent buffer overflows for large datasets.
+
+## Dependencies
+- Plan 001: Performance Analysis
+- Plan 003: Embedding Batching
+
+## Verification
+- Measure the number of upload calls and overall indexing time before and after changes.
+- Validate that all expected vectors appear in the database.
+
+## Acceptance Criteria
+- Upload step sends fewer, larger requests without data loss.
+- Indexing time decreases or remains stable with higher throughput.
+
+## Estimated Effort
+2 days for development and benchmarking.

--- a/planning/005-plan-profiling.md
+++ b/planning/005-plan-profiling.md
@@ -1,0 +1,26 @@
+# Plan 005: Profiling and Benchmarking
+
+## Objective
+Establish repeatable profiling scripts to quantify performance improvements over time.
+
+## Current Status
+Timing metrics are collected manually. There is no automated benchmark to compare changes.
+
+## Proposed Approach
+1. Create a small sample repository to act as benchmarking data.
+2. Write a script that runs the full indexing pipeline and records stage timings.
+3. Integrate with CI to run benchmarks on demand.
+
+## Dependencies
+- Plan 001: Performance Analysis
+
+## Verification
+- Running the script outputs timing data for each pipeline stage.
+- Results can be compared between commits.
+
+## Acceptance Criteria
+- Profiling script exists and generates reproducible metrics.
+- Metrics stored in a log or file for historical comparison.
+
+## Estimated Effort
+1–2 days for scripting and integration.

--- a/planning/plan-execute.md
+++ b/planning/plan-execute.md
@@ -1,0 +1,21 @@
+# Performance Improvement Roadmap
+
+This document tracks all tasks related to improving pipeline speed and latency. Each task is stored in a separate file within this directory.
+
+## Task List
+
+| ID  | File                                   | Status  | Description                                |
+|----|----------------------------------------|---------|--------------------------------------------|
+|001 | 001-plan-performance-analysis.md       | In Progress | Analyze current pipeline performance       |
+|002 | 002-plan-async-loading.md              | Planned | Implement asynchronous file loading        |
+|003 | 003-plan-embedding-batching.md         | Planned | Batch embeddings across documents          |
+|004 | 004-plan-db-upload-optimization.md     | Planned | Optimize database upload strategy          |
+|005 | 005-plan-profiling.md                  | Planned | Create profiling and benchmarking scripts  |
+
+## Key Decisions
+- Focus initially on profiling to understand baseline performance (Plan 001).
+- Subsequent tasks build on insights from the analysis.
+
+## Future Improvements
+- Additional tasks may be added as profiling reveals new bottlenecks.
+

--- a/scripts/perf_profile.py
+++ b/scripts/perf_profile.py
@@ -1,0 +1,50 @@
+import asyncio
+import time
+from pathlib import Path
+
+from src.pipeline.processor import Processor
+from src.pipeline.embedder import Embedder
+from src.pipeline.indexer import Indexer
+from src.pipeline.utils.configs import ProcessorConfig, EmbedderConfig, IndexerConfig
+
+async def create_dummy_files(path: Path, count: int = 300) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        (path / f"file_{i}.txt").write_text(f"dummy content {i}")
+
+def measure_time(label: str):
+    start = time.perf_counter()
+    yield
+    end = time.perf_counter()
+    print(f"{label}: {end - start:.2f}s")
+
+async def main():
+    tmp_dir = Path("temp_data")
+    await asyncio.to_thread(create_dummy_files, tmp_dir)
+
+    processor = Processor(ProcessorConfig())
+    embedder = Embedder(EmbedderConfig())
+    indexer = Indexer(IndexerConfig(), embedder.dense_embedder, embedder.sparse_embedder)
+
+    start = time.perf_counter()
+    try:
+        docs = await processor.load_documents(tmp_dir)
+        load_end = time.perf_counter()
+        print(f"Loaded {len(docs)} docs in {load_end - start:.2f}s")
+
+        processed = []
+        async for doc in processor.process_documents(docs):
+            if doc:
+                processed.append(doc)
+        process_end = time.perf_counter()
+        print(f"Processed {len(processed)} docs in {process_end - load_end:.2f}s")
+
+        await indexer.index_documents(processed)
+        index_end = time.perf_counter()
+        print(f"Indexed {len(processed)} docs in {index_end - process_end:.2f}s")
+    finally:
+        await processor.close()
+        await indexer.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/perf_profile.py
+++ b/scripts/perf_profile.py
@@ -2,10 +2,22 @@ import asyncio
 import time
 from pathlib import Path
 
-from src.pipeline.processor import Processor
-from src.pipeline.embedder import Embedder
-from src.pipeline.indexer import Indexer
-from src.pipeline.utils.configs import ProcessorConfig, EmbedderConfig, IndexerConfig
+try:
+    from src.pipeline.processor import Processor
+    from src.pipeline.embedder import Embedder
+    from src.pipeline.indexer import Indexer
+    from src.pipeline.utils.configs import (
+        ProcessorConfig,
+        EmbedderConfig,
+        IndexerConfig,
+    )
+except ModuleNotFoundError as exc:
+    missing = str(exc).split("No module named")[-1].strip().strip("'")
+    print(
+        f"Missing dependency: {missing}. Install requirements with 'pip install -r requirements.txt' "
+        "and ensure all optional packages are available."
+    )
+    raise SystemExit(1) from exc
 
 async def create_dummy_files(path: Path, count: int = 300) -> None:
     path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- start executing performance plan
- add perf_profile.py script to measure indexing time
- note missing packages in Plan 001
- mark performance analysis task as in progress

## Testing
- `pytest -q`
- `PYTHONPATH=. python scripts/perf_profile.py` *(fails: ModuleNotFoundError for langchain_community)*

------
https://chatgpt.com/codex/tasks/task_e_686438708f748331927815631916fcb8